### PR TITLE
修复初始化时工具箱会积压所有操作并在初始化完成后同时响应的问题

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from PySide6.QtCore import Qt, QResource
 from PySide6.QtWidgets import QApplication
 
 # 添加项目根目录到Python路径
-project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  
 sys.path.insert(0, project_root)
 
 from app.module.appManager import AppManager

--- a/app/module/mainWindow.py
+++ b/app/module/mainWindow.py
@@ -49,8 +49,22 @@ class MainWindow(FluentWindow):
         # 初始化导航
         self.initNavigation()
         
+        # 在SplashScreen期间阻止事件传播到主窗口
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
+        
         # 完成启动画面
         self.splashScreen.finish()
+        
+        # 处理所有待处理事件，清除可能积压的鼠标事件
+        QApplication.processEvents()
+        
+        # 短暂禁用主窗口以清除事件状态
+        self.setEnabled(False)
+        QApplication.processEvents()
+        
+        # 启动画面完成后恢复事件处理
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, False)
+        self.setEnabled(True)
         
     def initWindow(self):
         """初始化窗口"""

--- a/app/module/mainWindow.py
+++ b/app/module/mainWindow.py
@@ -58,13 +58,8 @@ class MainWindow(FluentWindow):
         # 处理所有待处理事件，清除可能积压的鼠标事件
         QApplication.processEvents()
         
-        # 短暂禁用主窗口以清除事件状态
-        self.setEnabled(False)
-        QApplication.processEvents()
-        
         # 启动画面完成后恢复事件处理
         self.setAttribute(Qt.WA_TransparentForMouseEvents, False)
-        self.setEnabled(True)
         
     def initWindow(self):
         """初始化窗口"""

--- a/app/module/mainWindow.py
+++ b/app/module/mainWindow.py
@@ -2,7 +2,7 @@
 """
 主窗口模块
 """
-from PySide6.QtCore import Qt, QSize, QTimer
+from PySide6.QtCore import Qt, QSize, Signal, QEvent
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QApplication
 from qfluentwidgets import (
@@ -18,70 +18,116 @@ from ..view.privateServerInterface import PrivateServerInterface
 
 class SplashScreenWithEventCapture(SplashScreen):
     """自定义SplashScreen，捕获所有鼠标事件"""
+    splashHidden = Signal()
+
     def mousePressEvent(self, event):
-        """捕获鼠标按下事件"""
         event.accept()
 
     def mouseReleaseEvent(self, event):
-        """捕获鼠标释放事件"""
         event.accept()
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self.splashHidden.emit()
 
 
 class MainWindow(FluentWindow):
     """主窗口类"""
-    
+
     def __init__(self):
         super().__init__()
-        
+
         # 设置主题
         setTheme(getattr(Theme, THEME_CONFIG["theme"]))
-        
+        self._splashActive = True
+        self._eventFilterInstalled = False
+
         # 初始化窗口
         self.initWindow()
-        
+
+        # 安装应用级事件过滤器，拦截鼠标事件
+        app = QApplication.instance()
+        if app is not None:
+            app.installEventFilter(self)
+            self._eventFilterInstalled = True
+
         # 创建启动画面
         self.splashScreen = SplashScreenWithEventCapture(self.windowIcon(), self)
         self.splashScreen.setIconSize(QSize(128, 128))
         self.splashScreen.titleBar.maxBtn.setHidden(True)
         self.splashScreen.raise_()
-        # 设置主窗口对鼠标事件透明
-        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
-        
+
         # 显示窗口
         self.show()
         QApplication.processEvents()
-        
+
         # 创建子界面
         self.homeInterface = HomeInterface(self)
         self.homeInterface.setCardsEnabled(False)
         self.settingInterface = SettingInterface(self)
         self.privateServerInterface = PrivateServerInterface(self)
-        
+
         # 连接信号
         self.homeInterface.navigateToInterface.connect(self.switchToInterface)
-        
+
         # 初始化导航
         self.initNavigation()
-        
+
         # 完成启动画面
-        self.splashScreen.finish()
         # 延迟恢复鼠标事件处理和卡片启用状态，确保SplashScreen动画完成
         def on_splash_finished():
+            # 继续保持事件过滤开启，先清空可能排队的用户输入
+            try:
+                from PySide6.QtCore import QEventLoop, QCoreApplication
+                app = QApplication.instance()
+                if app is not None:
+                    app.processEvents(QEventLoop.AllEvents, 50)
+                    app.processEvents(QEventLoop.AllEvents, 50)
+                    QCoreApplication.removePostedEvents(None)
+            except Exception:
+                pass
+
+            # 关闭拦截，恢复正常输入
+            self._splashActive = False
             self.setAttribute(Qt.WA_TransparentForMouseEvents, False)
+            app = QApplication.instance()
+            if app is not None and self._eventFilterInstalled:
+                app.removeEventFilter(self)
+                self._eventFilterInstalled = False
+            # 最后再启用卡片，避免排队事件触发
             self.homeInterface.setCardsEnabled(True)
-        QTimer.singleShot(50, on_splash_finished)
-        
+
+        self.splashScreen.splashHidden.connect(on_splash_finished)
+        self.splashScreen.finish()
+
+    def eventFilter(self, obj, event):
+        """在启动画面显示时屏蔽所有鼠标相关事件（包括悬停/移动/滚轮/菜单）"""
+        if getattr(self, "_splashActive", False):
+            if event.type() in {
+                QEvent.MouseButtonPress,
+                QEvent.MouseButtonRelease,
+                QEvent.MouseButtonDblClick,
+                QEvent.MouseMove,
+                QEvent.Wheel,
+                QEvent.HoverEnter,
+                QEvent.HoverLeave,
+                QEvent.HoverMove,
+                QEvent.ContextMenu,
+            }:
+                return True
+        return super().eventFilter(obj, event)
+
     def initWindow(self):
         """初始化窗口"""
         self.resize(WINDOW_CONFIG["width"], WINDOW_CONFIG["height"])
         self.setWindowTitle(WINDOW_CONFIG["title"])
-        
+
         # 设置窗口图标 - 使用绝对路径确保正确加载
         import os
         current_dir = os.path.dirname(os.path.abspath(__file__))
         logo_path = os.path.join(current_dir, '..', 'asset', 'logo.png')
         logo_path = os.path.abspath(logo_path)
-        
+
         if os.path.exists(logo_path):
             self.setWindowIcon(QIcon(logo_path))
             from ..function.logManager import logInfo
@@ -89,68 +135,66 @@ class MainWindow(FluentWindow):
         else:
             from ..function.logManager import logWarning
             logWarning(f"图标文件不存在: {logo_path}")
-            # 创建一个空的图标作为备用
             self.setWindowIcon(QIcon())
-        
-        # 禁用窗口大小调整 - 参考March7thAssistant的实现
+
+        # 禁用窗口大小调整
         self.titleBar.maxBtn.setHidden(True)
         self.titleBar.maxBtn.setDisabled(True)
         self.titleBar.setDoubleClickEnabled(False)
         self.setResizeEnabled(False)
-        
+
         # 创建状态栏
         self.StatusLabel = BodyLabel('就绪')
         self.StatusWidget = QWidget()
         statusLayout = QHBoxLayout(self.StatusWidget)
         statusLayout.addWidget(self.StatusLabel)
         statusLayout.addStretch(1)
-        
+
         # 居中显示窗口
         desktop = QApplication.primaryScreen().availableGeometry()
         w, h = desktop.width(), desktop.height()
         self.move(w//2 - self.width()//2, h//2 - self.height()//2)
-        
+
     def initNavigation(self):
         """初始化导航"""
         # 添加主界面到导航顶部
         self.addSubInterface(self.homeInterface, FIF.HOME, '主页')
-        
-        # 添加私服安装界面到导航
+
+        # 添加私服安装界面到导航滚动区
         self.addSubInterface(
             self.privateServerInterface, FIF.DOWNLOAD, '私服安装', NavigationItemPosition.SCROLL)
-        
+
         # 添加设置界面到导航底部
         self.addSubInterface(
             self.settingInterface, FIF.SETTING, '设置', NavigationItemPosition.BOTTOM)
-        
+
         # 设置默认显示主页
         self.navigationInterface.setCurrentItem(self.homeInterface.objectName())
-        
+
     def updateStatus(self, message):
         """更新状态栏消息"""
         self.StatusLabel.setText(message)
-        
+
     def switchToInterface(self, routeKey):
         """切换到指定界面"""
         from ..function.logManager import logInfo, logWarning
-        logInfo(f"尝试切换到界面: {routeKey}")
-        
-        # 直接使用switchTo方法切换界面
+        logInfo(f"尝试切换到界面 {routeKey}")
+
         interface_map = {
             'privateServerInterface': self.privateServerInterface,
             'settingInterface': self.settingInterface
         }
-        
+
         if routeKey in interface_map:
             try:
                 self.switchTo(interface_map[routeKey])
-                logInfo(f"成功切换到界面: {routeKey}")
+                logInfo(f"成功切换到界面 {routeKey}")
             except Exception as e:
                 logWarning(f"切换界面时出错: {routeKey}, 错误: {str(e)}")
         elif routeKey == 'homeInterface':
             try:
                 self.switchTo(self.homeInterface)
-                logInfo(f"成功切换到界面: {routeKey}")
+                logInfo(f"成功切换到界面 {routeKey}")
             except Exception as e:
                 logWarning(f"切换界面时出错: {routeKey}, 错误: {str(e)}")
         else:

--- a/app/module/mainWindow.py
+++ b/app/module/mainWindow.py
@@ -2,7 +2,7 @@
 """
 主窗口模块
 """
-from PySide6.QtCore import Qt, QSize
+from PySide6.QtCore import Qt, QSize, QTimer
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QApplication
 from qfluentwidgets import (
@@ -14,6 +14,17 @@ from ..function.variableConfig import WINDOW_CONFIG, THEME_CONFIG
 from ..view.settingInterface import SettingInterface
 from ..view.homeInterface import HomeInterface
 from ..view.privateServerInterface import PrivateServerInterface
+
+
+class SplashScreenWithEventCapture(SplashScreen):
+    """自定义SplashScreen，捕获所有鼠标事件"""
+    def mousePressEvent(self, event):
+        """捕获鼠标按下事件"""
+        event.accept()
+
+    def mouseReleaseEvent(self, event):
+        """捕获鼠标释放事件"""
+        event.accept()
 
 
 class MainWindow(FluentWindow):
@@ -29,10 +40,12 @@ class MainWindow(FluentWindow):
         self.initWindow()
         
         # 创建启动画面
-        self.splashScreen = SplashScreen(self.windowIcon(), self)
+        self.splashScreen = SplashScreenWithEventCapture(self.windowIcon(), self)
         self.splashScreen.setIconSize(QSize(128, 128))
         self.splashScreen.titleBar.maxBtn.setHidden(True)
         self.splashScreen.raise_()
+        # 设置主窗口对鼠标事件透明
+        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         
         # 显示窗口
         self.show()
@@ -40,6 +53,7 @@ class MainWindow(FluentWindow):
         
         # 创建子界面
         self.homeInterface = HomeInterface(self)
+        self.homeInterface.setCardsEnabled(False)
         self.settingInterface = SettingInterface(self)
         self.privateServerInterface = PrivateServerInterface(self)
         
@@ -49,17 +63,13 @@ class MainWindow(FluentWindow):
         # 初始化导航
         self.initNavigation()
         
-        # 在SplashScreen期间阻止事件传播到主窗口
-        self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
-        
         # 完成启动画面
         self.splashScreen.finish()
-        
-        # 处理所有待处理事件，清除可能积压的鼠标事件
-        QApplication.processEvents()
-        
-        # 启动画面完成后恢复事件处理
-        self.setAttribute(Qt.WA_TransparentForMouseEvents, False)
+        # 延迟恢复鼠标事件处理和卡片启用状态，确保SplashScreen动画完成
+        def on_splash_finished():
+            self.setAttribute(Qt.WA_TransparentForMouseEvents, False)
+            self.homeInterface.setCardsEnabled(True)
+        QTimer.singleShot(50, on_splash_finished)
         
     def initWindow(self):
         """初始化窗口"""

--- a/app/view/components/ElevatedCard.py
+++ b/app/view/components/ElevatedCard.py
@@ -16,6 +16,7 @@ class ElevatedCard(ElevatedCardWidget):
     def __init__(self, icon, title, content, routeKey, parent=None):
         super().__init__(parent=parent)
         self.routeKey = routeKey
+        self._enabled = True  # 自定义启用状态
         
         # 创建组件
         self.iconWidget = IconWidget(icon, self)
@@ -69,8 +70,23 @@ class ElevatedCard(ElevatedCardWidget):
             self.titleLabel.setStyleSheet("color: black;")
             self.contentLabel.setStyleSheet("color: rgba(0, 0, 0, 0.7);")
 
+    def setEnabled(self, enabled):
+        """设置组件启用状态"""
+        self._enabled = enabled
+        super().setEnabled(enabled)
+        
+    def isEnabled(self):
+        """获取组件启用状态"""
+        # 确保属性存在，避免初始化过程中的访问错误
+        return getattr(self, '_enabled', True)
+
+    def mousePressEvent(self, event):
+        """鼠标按下事件"""
+        # 不调用父类方法，完全控制事件
+        pass
+
     def mouseReleaseEvent(self, event):
         """鼠标释放事件"""
-        # 不调用父类的mouseReleaseEvent，避免触发父类的clicked信号
-        # super().mouseReleaseEvent(event)
-        self.clicked.emit(self.routeKey)
+        # 只有在启用状态下才响应点击事件
+        if self._enabled:
+            self.clicked.emit(self.routeKey)

--- a/app/view/components/ElevatedCard.py
+++ b/app/view/components/ElevatedCard.py
@@ -16,7 +16,6 @@ class ElevatedCard(ElevatedCardWidget):
     def __init__(self, icon, title, content, routeKey, parent=None):
         super().__init__(parent=parent)
         self.routeKey = routeKey
-        self._enabled = True  # 自定义启用状态
         
         # 创建组件
         self.iconWidget = IconWidget(icon, self)
@@ -70,23 +69,17 @@ class ElevatedCard(ElevatedCardWidget):
             self.titleLabel.setStyleSheet("color: black;")
             self.contentLabel.setStyleSheet("color: rgba(0, 0, 0, 0.7);")
 
-    def setEnabled(self, enabled):
-        """设置组件启用状态"""
-        self._enabled = enabled
-        super().setEnabled(enabled)
-        
-    def isEnabled(self):
-        """获取组件启用状态"""
-        # 确保属性存在，避免初始化过程中的访问错误
-        return getattr(self, '_enabled', True)
-
     def mousePressEvent(self, event):
         """鼠标按下事件"""
-        # 不调用父类方法，完全控制事件
-        pass
+        if self.isEnabled():
+            event.accept()
+        else:
+            event.ignore()
 
     def mouseReleaseEvent(self, event):
         """鼠标释放事件"""
-        # 只有在启用状态下才响应点击事件
-        if self._enabled:
+        if self.isEnabled():
             self.clicked.emit(self.routeKey)
+            event.accept()
+        else:
+            event.ignore()

--- a/app/view/components/ElevatedCard.py
+++ b/app/view/components/ElevatedCard.py
@@ -16,6 +16,7 @@ class ElevatedCard(ElevatedCardWidget):
     def __init__(self, icon, title, content, routeKey, parent=None):
         super().__init__(parent=parent)
         self.routeKey = routeKey
+        self._pressAccepted = False
         
         # 创建组件
         self.iconWidget = IconWidget(icon, self)
@@ -71,15 +72,17 @@ class ElevatedCard(ElevatedCardWidget):
 
     def mousePressEvent(self, event):
         """鼠标按下事件"""
-        if self.isEnabled():
+        self._pressAccepted = self.isEnabled()
+        if self._pressAccepted:
             event.accept()
         else:
             event.ignore()
 
     def mouseReleaseEvent(self, event):
         """鼠标释放事件"""
-        if self.isEnabled():
+        if self._pressAccepted and self.isEnabled():
             self.clicked.emit(self.routeKey)
             event.accept()
         else:
             event.ignore()
+        self._pressAccepted = False

--- a/app/view/homeInterface.py
+++ b/app/view/homeInterface.py
@@ -172,3 +172,8 @@ class HomeInterface(ScrollArea):
         elif routeKey == "donateInterface":
             # 跳转到赞助页面
             QDesktopServices.openUrl(QUrl("https://docs.qingfengawa.top/Donate.html"))
+
+    def setCardsEnabled(self, enabled):
+        """设置功能卡片的启用状态"""
+        for card in self.functionCardView.cards:
+            card.setEnabled(enabled)


### PR DESCRIPTION
修复了在splashScreen中，点击卡片的位置可以在splashScreen隐藏后响应卡片跳转的问题
现在，当SplashScreen显示时：
主窗口对所有鼠标事件完全透明
用户在SplashScreen期间的任何点击都会直接穿过主窗口
在SplashScreen消失后，系统会立即处理并清除任何可能的事件
主窗口的状态被重置，确保从一个干净的状态开始响应用户交互

## Sourcery 总结

防止在启动画面显示期间意外点击主窗口，并确保功能卡片仅在启用时响应

错误修复:
- 在启动画面激活期间，阻止主窗口上的鼠标事件，并在启动画面完成后清除所有待处理事件

功能增强:
- 引入自定义启用状态，并重写 ElevatedCard 中的 mousePressEvent 方法以有条件地触发点击事件
- 在 homeInterface 中添加 setCardsEnabled 方法以切换功能卡片的交互状态

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent unintended click-through to main window during splash screen and ensure function cards only respond when enabled

Bug Fixes:
- Block mouse events on the main window while the splash screen is active and clear any pending events after it finishes

Enhancements:
- Introduce a custom enabled state and override mousePressEvent in ElevatedCard to conditionally emit click events
- Add setCardsEnabled method in homeInterface to toggle the interactive state of function cards

</details>