### PR TITLE
feat: 升级依赖至 PyQt6

### DIFF
--- a/app/common/config.py
+++ b/app/common/config.py
@@ -13,7 +13,7 @@ class Language(Enum):
 
     CHINESE_SIMPLIFIED = QLocale(QLocale.Language.Chinese, QLocale.Country.China)
     CHINESE_TRADITIONAL = QLocale(QLocale.Language.Chinese, QLocale.Country.HongKong)
-    ENGLISH = QLocale(QLocale.Language.English, QLocale.Country.UnitedStates)
+    ENGLISH = QLocale(QLocale.Language.English)
     AUTO = QLocale()
 
 

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -2,7 +2,7 @@
 import sys
 from enum import Enum
 
-from PyQt5.QtCore import QLocale
+from PyQt6.QtCore import QLocale
 from qfluentwidgets import (qconfig, QConfig, ConfigItem, OptionsConfigItem, BoolValidator,
                             OptionsValidator, Theme, ConfigSerializer)
 

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -11,9 +11,9 @@ from .setting import CONFIG_FILE
 class Language(Enum):
     """ Language enumeration """
 
-    CHINESE_SIMPLIFIED = QLocale(QLocale.Chinese, QLocale.China)
-    CHINESE_TRADITIONAL = QLocale(QLocale.Chinese, QLocale.HongKong)
-    ENGLISH = QLocale(QLocale.English)
+    CHINESE_SIMPLIFIED = QLocale(QLocale.Language.Chinese, QLocale.Country.China)
+    CHINESE_TRADITIONAL = QLocale(QLocale.Language.Chinese, QLocale.Country.HongKong)
+    ENGLISH = QLocale(QLocale.Language.English, QLocale.Country.UnitedStates)
     AUTO = QLocale()
 
 

--- a/app/common/resource.py
+++ b/app/common/resource.py
@@ -6,7 +6,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from PyQt6 import QtCore
 
 qt_resource_data = b"\
 \x00\x0f\xc2\x82\

--- a/app/common/signal_bus.py
+++ b/app/common/signal_bus.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt6.QtCore import QObject, pyqtSignal
 
 
 class SignalBus(QObject):

--- a/app/view/home_interface.py
+++ b/app/view/home_interface.py
@@ -25,5 +25,5 @@ class HomeInterface(ScrollArea):
         self.setWidgetResizable(True)
         
         self.vBoxLayout.setSpacing(30)
-        self.vBoxLayout.setAlignment(Qt.AlignTop)
+        self.vBoxLayout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.vBoxLayout.setContentsMargins(36, 0, 36, 0)

--- a/app/view/home_interface.py
+++ b/app/view/home_interface.py
@@ -1,6 +1,6 @@
 # coding: utf-8
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QWidget, QVBoxLayout
 from qfluentwidgets import ScrollArea
 from ..common.style_sheet import StyleSheet
 

--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -3,9 +3,9 @@ import asyncio
 import logging
 import sys
 
-from PyQt5.QtCore import QObject, pyqtSignal
-from PyQt5.QtGui import QIcon, QColor
-from PyQt5.QtWidgets import QApplication
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtGui import QIcon, QColor
+from PyQt6.QtWidgets import QApplication
 
 from qfluentwidgets import NavigationItemPosition, SplitFluentWindow
 from qfluentwidgets import FluentIcon as FIF
@@ -92,8 +92,8 @@ class MainWindow(SplitFluentWindow):
     def createSplashScreen(self):
         """创建并显示启动画面"""
         from qfluentwidgets import SplashScreen
-        from PyQt5.QtGui import QIcon
-        from PyQt5.QtCore import QSize
+        from PyQt6.QtGui import QIcon
+        from PyQt6.QtCore import QSize
 
         self.splashScreen = SplashScreen(QIcon(':/app/images/logo.png'), self)
         self.splashScreen.setIconSize(QSize(120, 120))
@@ -123,7 +123,7 @@ class MainWindow(SplitFluentWindow):
     def downloadServersJson(self):
         """在程序启动时下载servers.json文件（在 SplashScreen 显示时执行）"""
         try:
-            from PyQt5.QtCore import QThread
+            from PyQt6.QtCore import QThread
 
             # 创建工作线程和工作对象
             self.download_thread = QThread()

--- a/app/view/private_server_interface.py
+++ b/app/view/private_server_interface.py
@@ -3,9 +3,9 @@ import json
 import logging
 import os
 import stat
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import QLabel, QVBoxLayout, QWidget
 from qfluentwidgets import ScrollArea, HeaderCardWidget, CheckBox, setFont, PrimaryPushButton, InfoBar, InfoBarPosition
 from ..common.style_sheet import StyleSheet
 

--- a/app/view/private_server_interface.py
+++ b/app/view/private_server_interface.py
@@ -96,7 +96,7 @@ class PrivateServerInterface(ScrollArea):
         self.vBoxLayout.addWidget(self.installButton)
 
         self.vBoxLayout.setSpacing(30)
-        self.vBoxLayout.setAlignment(Qt.AlignTop)
+        self.vBoxLayout.setAlignment(Qt.AlignmentFlag.AlignTop)
         self.vBoxLayout.setContentsMargins(36, 10, 36, 0)
 
     def onInstallButtonClicked(self):
@@ -112,7 +112,7 @@ class PrivateServerInterface(ScrollArea):
             InfoBar.warning(
                 title=self.tr('提示'),
                 content=self.tr('请至少选择一个服务器'),
-                orient=Qt.Horizontal,
+                orient=Qt.Orientation.Horizontal,
                 isClosable=True,
                 position=InfoBarPosition.TOP_RIGHT,
                 duration=3000,
@@ -133,7 +133,7 @@ class PrivateServerInterface(ScrollArea):
                 InfoBar.error(
                     title=self.tr('安装失败'),
                     content=self.tr('服务器数据未加载，请检查网络连接'),
-                    orient=Qt.Horizontal,
+                    orient=Qt.Orientation.Horizontal,
                     isClosable=True,
                     position=InfoBarPosition.TOP_RIGHT,
                     duration=3000,
@@ -266,7 +266,7 @@ class PrivateServerInterface(ScrollArea):
                 InfoBar.warning(
                     title=self.tr('安装终止'),
                     content=self.tr('所有服务器均重复'),
-                    orient=Qt.Horizontal,
+                    orient=Qt.Orientation.Horizontal,
                     isClosable=True,
                     position=InfoBarPosition.TOP_RIGHT,
                     duration=3000,
@@ -299,7 +299,7 @@ class PrivateServerInterface(ScrollArea):
             InfoBar.success(
                 title=self.tr('私服安装成功'),
                 content=self.tr(f'共安装了 {installed_count} 个服务器，{duplicate_count} 个服务器重复'),
-                orient=Qt.Horizontal,
+                orient=Qt.Orientation.Horizontal,
                 isClosable=True,
                 position=InfoBarPosition.TOP_RIGHT,
                 duration=3000,

--- a/app/view/setting_interface.py
+++ b/app/view/setting_interface.py
@@ -6,9 +6,9 @@ from qfluentwidgets import (SwitchSettingCard,
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import SettingCardGroup as CardGroup
 from qfluentwidgets import InfoBar
-from PyQt5.QtCore import Qt, QUrl
-from PyQt5.QtGui import QDesktopServices, QFont
-from PyQt5.QtWidgets import QWidget, QLabel
+from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtGui import QDesktopServices, QFont
+from PyQt6.QtWidgets import QWidget, QLabel
 
 from ..common.config import cfg, isWin11
 from ..common.setting import FEEDBACK_URL, AUTHOR, VERSION, YEAR

--- a/app/view/setting_interface.py
+++ b/app/view/setting_interface.py
@@ -109,7 +109,7 @@ class SettingInterface(ScrollArea):
 
     def __initWidget(self):
         self.resize(1000, 800)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setViewportMargins(0, 100, 0, 20)
         self.setWidget(self.scrollWidget)
         self.setWidgetResizable(True)

--- a/deploy.py
+++ b/deploy.py
@@ -14,7 +14,7 @@ args = [
     '--standalone',
     # '--windows-disable-console',
     '--follow-import-to=app' ,
-    '--plugin-enable=pyqt5' ,
+    '--plugin-enable=PyQt6' ,
     '--include-qt-plugins=sensible,styles' ,
     '--msvc=latest',
     '--show-memory' ,

--- a/deploy.py
+++ b/deploy.py
@@ -14,7 +14,7 @@ args = [
     '--standalone',
     # '--windows-disable-console',
     '--follow-import-to=app' ,
-    '--plugin-enable=PyQt6' ,
+    '--plugin-enable=pyqt6' ,
     '--include-qt-plugins=sensible,styles' ,
     '--msvc=latest',
     '--show-memory' ,

--- a/main.py
+++ b/main.py
@@ -23,11 +23,9 @@ if cfg.get(cfg.dpiScale) != "Auto":
 else:
     QApplication.setHighDpiScaleFactorRoundingPolicy(
         Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
-    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
 
 # create application
 app = QApplication(sys.argv)
-app.setAttribute(Qt.AA_DontCreateNativeWidgetSiblings)
 
 # 加载配置（必须在 QApplication 创建后）
 loadConfig()
@@ -48,7 +46,6 @@ w = MainWindow()
 # 在程序退出时清理缓存
 def cleanup_before_exit():
     w.cleanupCache()
-    app.quit()
 
 # 连接程序退出信号
 app.aboutToQuit.connect(cleanup_before_exit)

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ else:
 
 # create application
 app = QApplication(sys.argv)
+app.setAttribute(Qt.ApplicationAttribute.AA_DontCreateNativeWidgetSiblings)
 
 # 加载配置（必须在 QApplication 创建后）
 loadConfig()

--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ import logging
 import os
 import sys
 
-from PyQt5.QtCore import Qt, QTranslator
-from PyQt5.QtWidgets import QApplication
+from PyQt6.QtCore import Qt, QTranslator
+from PyQt6.QtWidgets import QApplication
 
 from app.common.config import cfg, loadConfig
 from app.view.main_window import MainWindow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5==5.15.11
-PyQt-Fluent-Widgets[full]==1.10.5
+PyQt6==6.10.2
+PyQt6-Fluent-Widgets[full]==1.11.0
 ruff>=0.14.13
 aiohttp>=3.13.3


### PR DESCRIPTION
升级 PyQt5 至 6 以提高与 Nuitka 的兼容性。

## Summary by Sourcery

将应用程序升级为使用 PyQt6，并使相关代码、控件和部署配置与新的 Qt API 保持一致。

增强功能：
- 调整 Qt 枚举、区域设置配置和信号导入方式以适配 PyQt6 API。
- 更新启动画面、线程相关导入以及滚动条策略为其在 PyQt6 中的对应实现。
- 移除在 PyQt6 下不再需要的已弃用高 DPI 和原生控件同级属性。

构建：
- 将运行时依赖从 PyQt5 切换为 PyQt6，并在依赖列表中更新 PyQt Fluent Widgets 的版本。
- 更新 Nuitka 部署配置以启用 PyQt6 插件，替代原先的 PyQt5 插件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the application to use PyQt6 and align related code, widgets, and deployment configuration with the new Qt API.

Enhancements:
- Adjust Qt enums, locale configuration, and signal imports to the PyQt6 API.
- Update splash screen, threading imports, and scroll bar policies to their PyQt6 equivalents.
- Remove deprecated high-DPI and native widget sibling attributes no longer needed under PyQt6.

Build:
- Switch runtime dependency from PyQt5 to PyQt6 and update PyQt Fluent Widgets version in requirements.
- Update Nuitka deployment configuration to enable the PyQt6 plugin instead of the PyQt5 plugin.

</details>